### PR TITLE
Ensure timestamp index can be monotonic

### DIFF
--- a/correct6x/corrections.py
+++ b/correct6x/corrections.py
@@ -38,6 +38,7 @@ def compute_ils_correction(image_df):
 
     image_df['timestamp'] = image_df.apply(lambda row: imgparse.get_timestamp(row.image_path, row.EXIF), axis=1)
     image_df.set_index('timestamp', drop=True, inplace=True)
+    image_df.sort_index(inplace=True)
 
     image_df['ILS'] = image_df.image_path.apply(imgparse.get_ils)
     image_df['averaged_ILS'] = image_df.groupby('image_root').ILS.transform(_rolling_avg)


### PR DESCRIPTION
Pandas requires the index used when computing a rolling avg function to be monotonic.  Since the initial list of files in your populating of the panads dataframe makes no guarantee of order (especially on high throughput filesystems like XFS), the index needs to be sorted so when the group selected rolling avg is run it won't error for being non-monotonic (This happened to me, hence this fix).

Cheers!