### PR TITLE
 Bump imgparse version for reg expr fix

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,4 +20,4 @@ dependencies:
   # subpackage dependencies
   # Sentera dependencies
   - pip:
-    - git+https://github.com/SenteraLLC/py-image-metadata-parser.git@v1.9.2
+    - git+https://github.com/SenteraLLC/py-image-metadata-parser.git@v1.9.3

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         "pandas",
         "tqdm",
         "opencv-contrib-python",
-        "imgparse @ git+https://github.com/SenteraLLC/py-image-metadata-parser.git@v1.9.2"
+        "imgparse @ git+https://github.com/SenteraLLC/py-image-metadata-parser.git@v1.9.3"
     ],
     extras_require={
         "dev": ["pytest", "sphinx_rtd_theme", "pre-commit", "m2r", "sphinx"],


### PR DESCRIPTION
The SunSensor metadata isn't read due to the newline character being in the SEQ reg exp.  Looks like you guys fixed that, but the version referenced here doesn't reflect that change.  1.9.3 looks to be the first tagged version that does.

Cheers!