### PR TITLE
Set XMP Camera:BlackCurrent value to 0 for corrected images

### DIFF
--- a/imgcorrect/metadata.py
+++ b/imgcorrect/metadata.py
@@ -21,6 +21,8 @@ def copy_exif(image_df_row, exiftool_path):
         "--xmp-Camera:ColorTransform",
         "--xmp-Camera:SunSensor",
         "-xmp-Camera:IsNormalized=1",
+        "-xmp-Camera:BlackCurrent=",
+        "-xmp-Camera:BlackCurrent=0",
     ]
     if image_df_row.reduce_xmp:
         cent_arr, fwhm_arr = imgparse.get_wavelength_data(image_df_row.image_path)


### PR DESCRIPTION
# Set XMP Camera:BlackCurrent value to 0 for corrected images
## What?
Set XMP Camera:BlackCurrent value to 0 for corrected images
## Why?
Third party sensors (like the M3M) may have BlackCurrent values greater than 0. These mean that all pixel values less than or equal to the BlackCurrent value should be interpreted as black.

Radiometric corrections scale pixel values from 0-1, with 0 being black. Higher black current values cause tools like Metashape to interpret corrected images as completely black, so this metadata value must be corrected.
## PR Checklist
- [X] Merged latest master
- [X] Updated version number
- [X] Version numbers match between package ``__version__`` and *pyproject.toml*
- [ ] All private git packages are at their newest version in both *pyproject.toml* and *environment.yml*
- [ ] All git package version numbers match between *pyproject.toml* and *environment.yml*
- [ ] dist/ImageryCorrector.exe and dist/GetCorrectionsCsv.exe have been rebuilt
## Breaking Changes